### PR TITLE
fix(#17): added a css style if the height is lower than 790px, do not display the images

### DIFF
--- a/styles/ProfilePage.module.css
+++ b/styles/ProfilePage.module.css
@@ -48,6 +48,7 @@
 
 .profileBottomText {
   padding-top: 1rem;
+  padding-bottom: 1rem;
   /* paragraphe 1 */
 
   font-family: "Arial";
@@ -122,10 +123,18 @@
     flex-direction: column-reverse;
   }
 
-  .profileImageContainer {
-    margin-left: 10vw;
-    margin-top: 5vh;
-    margin-bottom: 10vh;
+  @media (min-height: 790px) {
+    .profileImageContainer {
+      margin-left: 10vw;
+      margin-top: 5vh;
+      margin-bottom: 10vh;
+    }
+  }
+
+  @media (max-height: 790px) {
+    .profileImageContainer {
+      display: none;
+    }
   }
 
   .profile {
@@ -133,9 +142,6 @@
     width: 30vw;
     height: 40vw;
     position: absolute;
-    /* place right side */
-    /* position: absolute; */
-    /* set margin to 10% of viewport */
     /* set border radius to 50% */
     border-radius: 10%;
     /* set border to 1px solid white */


### PR DESCRIPTION
## Summary
This pull request contains the fix for the issue #17 

## Before
![image](https://user-images.githubusercontent.com/13793276/202561626-c7af05a0-3f90-4f08-b8d9-b204cfd896d0.png)

## After
![image](https://user-images.githubusercontent.com/13793276/202561513-b8bc482d-8bf0-4f93-87b7-079b3ffb5ba7.png)
